### PR TITLE
Update opam file

### DIFF
--- a/ppx_accessor.opam
+++ b/ppx_accessor.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml" {>= "4.09.0"}
   "dune"  {>= "2.0.0"}
   "ppxlib" {>= "0.14.0"}
+  "accessor" {>= "v0.14.1" & < "v0.15"}
 ]
 synopsis: "[@@deriving] plugin to generate accessors for use with the Accessor libraries"
 description: "


### PR DESCRIPTION
The opam file was wrong and out of sync with the released opam file on opam-repository.

Keeping it up to date helps with the process of upgrading the ppx ecosystem, see https://github.com/ocaml-ppx/ppxlib/issues/218.