### PR TITLE
Adapt to Ppxlib's API change

### DIFF
--- a/ppx_accessor.opam
+++ b/ppx_accessor.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml" {>= "4.09.0"}
   "dune"  {>= "2.0.0"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.23.0"}
   "accessor" {>= "v0.14.1" & < "v0.15"}
 ]
 synopsis: "[@@deriving] plugin to generate accessors for use with the Accessor libraries"

--- a/src/name.ml
+++ b/src/name.ml
@@ -8,5 +8,5 @@ let to_constructor_string = Fn.id
 
 let to_lowercase_string t =
   let string = String.lowercase t in
-  if Caml.Hashtbl.mem Lexer.keyword_table string then string ^ "_" else string
+  if Keyword.is_keyword string then string ^ "_" else string
 ;;


### PR DESCRIPTION
Ppxlib is removing `Lexer.keyword_table` from the API in exchange for the more lightweight `Keyword.is_keyword`. See [this PR](https://github.com/ocaml-ppx/ppxlib/pull/227). This commit adapts ppx_accessor to that change.

It would be good to merge this PR when ppxlib 0.23.0 gets released. I'll notify here when that happens.